### PR TITLE
new tab when clicking view site in admin navbar

### DIFF
--- a/frontend/app/components/admin_navbar.tsx
+++ b/frontend/app/components/admin_navbar.tsx
@@ -20,7 +20,7 @@ const AdminNavbar: React.FC = () => {
   return (
     <nav className={styles.adminNavbar}>
       <div className={styles.container}>
-        <Link href="/" className={styles.viewSiteLink}>
+        <Link href="/" target="_blank" className={styles.viewSiteLink}>
           View Site
         </Link>
 


### PR DESCRIPTION
# 🚀 Pull Request Template

## 📋 Summary

Fixed the "View Site" hyperlink in the admin navbar not opening the site/link on a new tab, but rather loading it in the same opened page/dashboard.

## ✅ Checklist

- [ ] 🧹 Code follows the project's coding standards.
- [ ] 📚 Documentation has been updated (if necessary).
- [ ] 🧪 Tests have been written or updated (if applicable).
- [ ] ✅ All tests pass successfully.