### PR TITLE
remove red asterisk on image on edit

### DIFF
--- a/frontend/app/admin/(protected)/cabins/edit/[id]/form.tsx
+++ b/frontend/app/admin/(protected)/cabins/edit/[id]/form.tsx
@@ -178,8 +178,7 @@ export default function CabinForm({ id, defaultValues }: CabinFormProps) {
 
               <div className={styles.form_group}>
                 <label>
-                  Rate
-                  <span className={styles.required}>*</span>
+                  Rate <span className={styles.required}>*</span>
                 </label>
                 <input
                   type="number"

--- a/frontend/app/admin/(protected)/cabins/edit/[id]/form.tsx
+++ b/frontend/app/admin/(protected)/cabins/edit/[id]/form.tsx
@@ -197,7 +197,7 @@ export default function CabinForm({ id, defaultValues }: CabinFormProps) {
 
             <div className={styles.form_group}>
               <label>
-                Upload Image <span className={styles.required}>*</span>
+                Upload Image
               </label>
               <input
                 type="file"

--- a/frontend/app/admin/(protected)/cabins/edit/[id]/form.tsx
+++ b/frontend/app/admin/(protected)/cabins/edit/[id]/form.tsx
@@ -223,7 +223,7 @@ export default function CabinForm({ id, defaultValues }: CabinFormProps) {
           {/* Buttons */}
           <div className={styles.full_width}>
             <div className={styles.button_container}>
-              <CustomButton type="submit" label="Edit Cabin" />
+              <CustomButton type="submit" label="Save Changes" />
               <CustomButton
                 type="button"
                 label="Reset"

--- a/frontend/app/admin/(protected)/day-tour-activities/edit/[id]/form.tsx
+++ b/frontend/app/admin/(protected)/day-tour-activities/edit/[id]/form.tsx
@@ -159,7 +159,7 @@ export default function EditDayTour({ id, defaultValues }: DayTourProps) {
 
             <div className={styles.form_group}>
               <label>
-                Upload Image <span className={styles.required}>*</span>
+                Upload Image
               </label>
               <input
                 type="file"


### PR DESCRIPTION
## 📋 Summary

- Removed the red asterisks from the Edit interfaces of upload image in both Cabin and Day Tour
- Changed the text of the submit button from "Edit Cabin" to "Save Changes"

Closes #250 