### PR TITLE
double invalid error when uploading an image in edit day tour

### DIFF
--- a/frontend/app/admin/(protected)/day-tour-activities/edit/[id]/form.tsx
+++ b/frontend/app/admin/(protected)/day-tour-activities/edit/[id]/form.tsx
@@ -169,12 +169,6 @@ export default function EditDayTour({ id, defaultValues }: DayTourProps) {
                   }
                 }}
               />
-              {!errors.file && (
-                <p className={`${styles.message} ${styles.success}`}>
-                  Image uploaded successfully!
-                </p>
-              )}
-
               {errors.file && (
                 <p className={`${styles.message} ${styles.error}`}>
                   {errors.file.message}

--- a/frontend/app/admin/(protected)/day-tour-activities/edit/[id]/form.tsx
+++ b/frontend/app/admin/(protected)/day-tour-activities/edit/[id]/form.tsx
@@ -174,12 +174,6 @@ export default function EditDayTour({ id, defaultValues }: DayTourProps) {
                   {errors.file.message}
                 </p>
               )}
-
-              {errors.file && (
-                <p className={`${styles.message} ${styles.error}`}>
-                  {errors.file.message}
-                </p>
-              )}
             </div>
           </div>
 


### PR DESCRIPTION
## 📋 Summary

Removed the duplicate error message for upload image field in the Edit interface of Day Tour and also removed an irrelevant label for it.

Closes #252 