### PR TITLE
Error Validation on input fields for Name and Description (50, 100 respectively) - Add

### DIFF
--- a/frontend/app/admin/(protected)/cabins/add/form.tsx
+++ b/frontend/app/admin/(protected)/cabins/add/form.tsx
@@ -214,7 +214,6 @@ export default function CabinForm() {
                   type="number"
                   placeholder="₱"
                   {...register("price")}
-                  min="1"
                   step="0.01"
                   className={errors.price && styles.invalid_input}
                 />

--- a/frontend/app/admin/(protected)/cabins/add/form.tsx
+++ b/frontend/app/admin/(protected)/cabins/add/form.tsx
@@ -145,6 +145,7 @@ export default function CabinForm() {
                 placeholder="Cabin name"
                 {...register("name")}
                 className={errors.name && styles.invalid_input}
+                maxLength={51}
               />
               {errors.name && (
                 <span className={styles.error}>{errors.name.message}</span>

--- a/frontend/app/admin/(protected)/cabins/add/form.tsx
+++ b/frontend/app/admin/(protected)/cabins/add/form.tsx
@@ -160,6 +160,7 @@ export default function CabinForm() {
                 placeholder="Description"
                 {...register("description")}
                 className={errors.description && styles.invalid_input}
+                maxLength={101}
               />
               {errors.description && (
                 <span className={styles.error}>

--- a/frontend/app/admin/(protected)/cabins/edit/[id]/form.tsx
+++ b/frontend/app/admin/(protected)/cabins/edit/[id]/form.tsx
@@ -118,6 +118,7 @@ export default function CabinForm({ id, defaultValues }: CabinFormProps) {
                 placeholder="Cabin name"
                 {...register("name")}
                 className={errors.name && styles.invalid_input}
+                maxLength={51}
               />
               {errors.name && (
                 <span className={styles.error}>{errors.name.message}</span>
@@ -132,6 +133,7 @@ export default function CabinForm({ id, defaultValues }: CabinFormProps) {
                 placeholder="Description"
                 {...register("description")}
                 className={errors.description && styles.invalid_input}
+                maxLength={101}
               />
               {errors.description && (
                 <span className={styles.error}>

--- a/frontend/app/admin/(protected)/day-tour-activities/add/form.tsx
+++ b/frontend/app/admin/(protected)/day-tour-activities/add/form.tsx
@@ -123,7 +123,7 @@ export default function DayTourForm() {
               <label>
                 Title<span className={styles.required}>*</span>
               </label>
-              <input type="text" {...register("name")} maxLength={50} />
+              <input type="text" {...register("name")} maxLength={51} />
               {errors.name && (
                 <span className={styles.error}>{errors.name.message}</span>
               )}
@@ -133,7 +133,7 @@ export default function DayTourForm() {
               <label>
                 Description <span className={styles.required}>*</span>
               </label>
-              <textarea {...register("description")} maxLength={100} />
+              <textarea {...register("description")} maxLength={101} />
               {errors.description && (
                 <span className={styles.error}>
                   {errors.description.message}

--- a/frontend/app/admin/(protected)/day-tour-activities/edit/[id]/form.tsx
+++ b/frontend/app/admin/(protected)/day-tour-activities/edit/[id]/form.tsx
@@ -116,6 +116,7 @@ export default function EditDayTour({ id, defaultValues }: DayTourProps) {
                 type="text"
                 {...register("name")}
                 className={errors.name && styles.invalid_input}
+                maxLength={51}
                 required
               />
               {errors.name && (
@@ -130,6 +131,7 @@ export default function EditDayTour({ id, defaultValues }: DayTourProps) {
               <textarea
                 {...register("description")}
                 className={errors.description && styles.invalid_input}
+                maxLength={101}
                 required
               />
               {errors.description && (


### PR DESCRIPTION
## 📋 Summary

Changed the max length of the add and edit interfaces of Cabin and Day Tour and also removed the min constraint from the rate input field in the Add Cabin interface.

Closes #253 