### PR TITLE
removed image uploaded successfully from edit cabin

### DIFF
--- a/frontend/app/admin/(protected)/cabins/edit/[id]/form.tsx
+++ b/frontend/app/admin/(protected)/cabins/edit/[id]/form.tsx
@@ -212,12 +212,6 @@ export default function CabinForm({ id, defaultValues }: CabinFormProps) {
                   }
                 }}
               />
-              {!errors.file && (
-                <p className={`${styles.message} ${styles.success}`}>
-                  Image uploaded successfully!
-                </p>
-              )}
-
               {errors.file && (
                 <p className={`${styles.message} ${styles.error}`}>
                   {errors.file.message}


### PR DESCRIPTION
## 📋 Summary

Removed the "Image uploaded successfully!" label from Edit Cabin.

Closes #265 
